### PR TITLE
Add Next.js base setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,24 @@
-# GPT
+# BuscaTuDepa
 
-Este repositorio proporciona un ejemplo simple de uso del proyecto GPT.
+Aplicación creada con Next.js y TypeScript para encontrar departamentos. Este repo contiene la configuración inicial del proyecto con Tailwind CSS.
+
+## Desarrollo local
+
+1. Instala las dependencias (requiere acceso a npm):
+   ```bash
+   npm install
+   ```
+2. Inicia el servidor de desarrollo:
+   ```bash
+   npm run dev
+   ```
+
+## Despliegue en Vercel
+
+1. Crea una cuenta en [Vercel](https://vercel.com) si aún no la tienes.
+2. Instala la CLI de Vercel de forma global:
+   ```bash
+   npm install -g vercel
+   ```
+3. Ejecuta el comando `vercel` y sigue los pasos interactivos para desplegar.
+4. Cada vez que hagas `git push`, Vercel realizará el despliegue automáticamente.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+}
+
+module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "busca-tu-depa",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "10.4.17",
+    "postcss": "8.4.32",
+    "tailwindcss": "3.4.4",
+    "typescript": "5.4.3"
+  }
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,6 @@
+import '@/styles/globals.css'
+import type { AppProps } from 'next/app'
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,18 @@
+import Head from 'next/head'
+
+export default function Home() {
+  return (
+    <>
+      <Head>
+        <title>BuscaTuDepa</title>
+        <meta name="description" content="Encuentra el departamento perfecto" />
+      </Head>
+      <main className="flex min-h-screen flex-col items-center justify-center bg-gray-50">
+        <h1 className="text-4xl font-bold text-blue-600">Bienvenido a BuscaTuDepa</h1>
+        <p className="mt-4 text-lg text-gray-700 text-center max-w-xl">
+          Encuentra tu departamento ideal en la ciudad de manera fácil. Muy pronto podrás buscar en el mapa y ver un listado de opciones disponibles.
+        </p>
+      </main>
+    </>
+  )
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,17 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html,
+body {
+  padding: 0;
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
+    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"],
+    "baseUrl": "."
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- initialize Next.js project structure for *BuscaTuDepa*
- configure TypeScript and Tailwind CSS
- add landing page
- document how to run locally and deploy to Vercel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68430d5e0308832e84d5b592420b889f